### PR TITLE
Bug 832089 / GTNWSRP-290

### DIFF
--- a/producer/src/main/java/org/gatein/wsrp/producer/handlers/PortletManagementHandler.java
+++ b/producer/src/main/java/org/gatein/wsrp/producer/handlers/PortletManagementHandler.java
@@ -558,6 +558,16 @@ public class PortletManagementHandler extends ServiceHandler implements PortletM
       checkUserAuthorization(userContext);
 
       List<String> names = getPortletProperties.getNames();
+      // workaround for GTNWSRP-290:
+      if (names.size() == 1)
+      {
+         final String name = names.get(0);
+         if(ParameterValidation.isNullOrEmpty(name))
+         {
+            names = Collections.emptyList();
+         }
+      }
+
       Set<String> keys = new HashSet<String>(names);
 
       try
@@ -566,7 +576,7 @@ public class PortletManagementHandler extends ServiceHandler implements PortletM
          org.gatein.pc.api.PortletContext jbpContext = WSRPUtils.convertToPortalPortletContext(portletContext);
 
          RegistrationLocal.setRegistration(registration);
-         if (keys != null)
+         if (!keys.isEmpty())
          {
             properties = producer.getPortletInvoker().getProperties(jbpContext, keys);
          }

--- a/wsrp-producer-war/src/test/java/org/gatein/wsrp/protocol/v1/PortletManagementTestCase.java
+++ b/wsrp-producer-war/src/test/java/org/gatein/wsrp/protocol/v1/PortletManagementTestCase.java
@@ -243,6 +243,20 @@ public class PortletManagementTestCase extends NeedPortletHandleTest
    }
 
    @Test
+   public void testGetPortletPropertiesNoKeys() throws Exception
+   {
+      String handle = getDefaultHandle();
+      V1PortletContext initialContext = WSRP1TypeFactory.createPortletContext(handle);
+      V1GetPortletProperties getPortletProperties = WSRP1TypeFactory.createGetPortletProperties(null, initialContext);
+
+      V1PropertyList response = producer.getPortletProperties(getPortletProperties);
+      List<V1Property> expected = new ArrayList<V1Property>(2);
+      Collections.addAll(expected, WSRP1TypeFactory.createProperty("prefName1", "en", "prefValue1"),
+         WSRP1TypeFactory.createProperty("prefName2", "en", "prefValue2"));
+      checkGetPropertiesResponse(response, expected);
+   }
+
+   @Test
    public void testGetPortletPropertiesNoRegistration() throws Exception
    {
       String handle = getDefaultHandle();
@@ -258,12 +272,8 @@ public class PortletManagementTestCase extends NeedPortletHandleTest
          WSRP1TypeFactory.createProperty("prefName2", "en", "prefValue2"));
       checkGetPropertiesResponse(response, expected);
 
-      //This part of the tests doesn't make sense as names is a reference to the list, not a clone
-      //Changed test to check for a empty list since calling names.clear
       names.clear();
       response = producer.getPortletProperties(getPortletProperties);
-      //checkGetPropertiesResponse(response, expected);
-      checkGetPropertiesResponse(response, new ArrayList<V1Property>());
 
       names.add("prefName2");
       response = producer.getPortletProperties(getPortletProperties);


### PR DESCRIPTION
- Fixed improper behavior of getPortletProperties when an empty list of names was passed. - Added test case.
- Fixed improper testGetPortletPropertiesNoRegistration test.
