### PR TITLE
Fixed getPropertyAccessor always improperly reloading.

### DIFF
--- a/common/src/main/java/org/gatein/wsrp/WSRPUtils.java
+++ b/common/src/main/java/org/gatein/wsrp/WSRPUtils.java
@@ -680,7 +680,10 @@ public class WSRPUtils
 
    static PropertyAccessor getPropertyAccessor(boolean reload)
    {
-      propertyAccessor = new DefaultPropertyAccessor();
+      if (reload)
+      {
+         propertyAccessor = new DefaultPropertyAccessor();
+      }
       return propertyAccessor;
    }
 


### PR DESCRIPTION
Fixed getPropertyAccessor(boolean reload) that was reloading the accessor all the time regardless of reload parameter. (cherry picked from commit 59cb0f0)
