### PR TITLE
GTN-WSRP-331

### DIFF
--- a/ws-security/jboss7/src/main/java/org/gatein/wsrp/wss/cxf/producer/GTNSubjectCreatingInterceptor.java
+++ b/ws-security/jboss7/src/main/java/org/gatein/wsrp/wss/cxf/producer/GTNSubjectCreatingInterceptor.java
@@ -91,10 +91,9 @@ public class GTNSubjectCreatingInterceptor extends SubjectCreatingInterceptor
          }
       }
 
+      HttpServletRequest request = (HttpServletRequest)msg.get("HTTP.REQUEST");
       if (wsUsernameTokenPrincipal != null)
       {
-         HttpServletRequest request = (HttpServletRequest)msg.get("HTTP.REQUEST");
-
          String username = wsUsernameTokenPrincipal.getName();
          String password = wsUsernameTokenPrincipal.getPassword();
 
@@ -110,6 +109,20 @@ public class GTNSubjectCreatingInterceptor extends SubjectCreatingInterceptor
          catch (ServletException e)
          {
             // FIXME
+            e.printStackTrace();
+         }
+      }
+      // if we didn't get a wsUsernameTokenPrincipal but there is a remote user logged in, then we need to log out the user
+      // This handles the situations where ws-security was enabled, but has currently been disabled for the consumer
+      else if (request.getRemoteUser() != null)
+      {
+         try
+         {
+            request.logout();
+         }
+         catch (ServletException e)
+         {
+            //FIXME
             e.printStackTrace();
          }
       }


### PR DESCRIPTION
Log out a user who has been previously authenticated via ws-security if the message no longer contains the user's credentials. This will log out the user when ws-security has been disabled.
