### PR TITLE
GTNWSRP-337 Allow MimeResponse.mimeType to be null per specification

### DIFF
--- a/common/src/main/java/org/gatein/wsrp/WSRPTypeFactory.java
+++ b/common/src/main/java/org/gatein/wsrp/WSRPTypeFactory.java
@@ -632,8 +632,6 @@ public class WSRPTypeFactory
 
    public static <T extends MimeResponse> T createMimeResponse(String mimeType, String itemString, byte[] itemBinary, Class<T> clazz)
    {
-      //TODO: this should be allowed to be null
-      ParameterValidation.throwIllegalArgExceptionIfNullOrEmpty(mimeType, "MIME type", "MimeResponse");
       if ((itemString == null) && (itemBinary == null || itemBinary.length == 0))
       {
          throw new IllegalArgumentException("MimeResponse requires either a non-null markup string or binary markup.");

--- a/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/MimeResponseHandler.java
+++ b/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/MimeResponseHandler.java
@@ -122,11 +122,7 @@ public abstract class MimeResponseHandler<Invocation extends PortletInvocation, 
          }
       }
 
-      String mimeType = mimeResponse.getMimeType();
-      if (ParameterValidation.isNullOrEmpty(mimeType))
-      {
-         return new ErrorResponse(new IllegalArgumentException("No MIME type was provided for portlet content."));
-      }
+      final String mimeType = mimeResponse.getMimeType();
 
       if (Boolean.TRUE.equals(mimeResponse.isRequiresRewriting()))
       {

--- a/producer/src/main/java/org/gatein/wsrp/producer/resources/ResourceServingServlet.java
+++ b/producer/src/main/java/org/gatein/wsrp/producer/resources/ResourceServingServlet.java
@@ -57,7 +57,11 @@ public class ResourceServingServlet extends HttpServlet
          byte[] itemBinary = resourceContext.getItemBinary();
          String itemString = resourceContext.getItemString();
 
-         resp.setContentType(resourceContext.getMimeType());
+         final String mimeType = resourceContext.getMimeType();
+         if (!ParameterValidation.isNullOrEmpty(mimeType))
+         {
+            resp.setContentType(mimeType);
+         }
 
          if (itemBinary != null && itemBinary.length > 0)
          {


### PR DESCRIPTION
(cherry-picked from 442f658)
