### PR TITLE
GTNWSRP-347 Improved cookie handling

### DIFF
--- a/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/DirectResourceServingHandler.java
+++ b/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/DirectResourceServingHandler.java
@@ -63,15 +63,10 @@ public class DirectResourceServingHandler extends ResourceHandler
       URL url = new URL(resourceURL);
       URLConnection urlConnection = url.openConnection();
 
-      ProducerSessionInformation sessionInfo = RequestHeaderClientHandler.getCurrentProducerSessionInformation();
-      if (sessionInfo != null)
+      final String cookieValue = RequestHeaderClientHandler.createCoalescedCookieFromCurrentInfo();
+      if (cookieValue.length() != 0)
       {
-         String cookie = RequestHeaderClientHandler.createCookie(sessionInfo);
-
-         if (cookie.length() != 0)
-         {
-            urlConnection.addRequestProperty(CookieUtil.COOKIE, cookie);
-         }
+         urlConnection.addRequestProperty(CookieUtil.COOKIE, cookieValue);
       }
 
       String contentType = urlConnection.getContentType();
@@ -90,7 +85,7 @@ public class DirectResourceServingHandler extends ResourceHandler
             {
                if (CookieUtil.SET_COOKIE.equals(key))
                {
-                  Cookie[] cookies = CookieUtil.extractCookiesFrom(url, values.toArray(new String[values.size()]));
+                  List<Cookie> cookies = CookieUtil.extractCookiesFrom(url, values);
                   List<javax.servlet.http.Cookie> propCookies = props.getCookies();
                   for (Cookie cookie : cookies)
                   {

--- a/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/SessionHandler.java
+++ b/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/SessionHandler.java
@@ -142,18 +142,11 @@ public class SessionHandler implements SessionEventListener
          sessionInformation.setPerGroupCookies(true);
          Map<String, Set<Portlet>> groups = consumer.getPortletGroupMap();
 
-         try
+         for (String groupId : groups.keySet())
          {
-            for (String groupId : groups.keySet())
-            {
-               RequestHeaderClientHandler.setCurrentGroupId(groupId);
-               log.debug("Initializing cookie for group '" + groupId + "'.");
-               initCookie(invocation, retryIfFails);
-            }
-         }
-         finally
-         {
-            resetCurrentlyHeldInformation();
+            RequestHeaderClientHandler.setCurrentGroupId(groupId);
+            log.debug("Initializing cookie for group '" + groupId + "'.");
+            initCookie(invocation, retryIfFails);
          }
       }
 
@@ -433,6 +426,10 @@ public class SessionHandler implements SessionEventListener
       int index = sessionId.lastIndexOf(".");
       if (index > 0)
       {
+         if (log.isDebugEnabled())
+         {
+            log.debug("Removed '" + sessionId.substring(index) + "' from session id '" + sessionId + "' to get the raw version.");
+         }
          return sessionId.substring(0, index);
       }
       else

--- a/consumer/src/test/java/org/gatein/wsrp/protocol/v1/MarkupTestCase.java
+++ b/consumer/src/test/java/org/gatein/wsrp/protocol/v1/MarkupTestCase.java
@@ -187,7 +187,7 @@ public class MarkupTestCase extends V1ConsumerBaseTest
       ExtendedAssert.assertFalse(sessionInfo.isPerGroupCookies());
       ExtendedAssert.assertTrue(sessionInfo.isInitCookieDone());
 
-      ExtendedAssert.assertNotNull(sessionInfo.getUserCookie());
+      ExtendedAssert.assertNotNull(sessionInfo.getUserCookies());
 
       ExtendedAssert.assertEquals(1, behavior.getInitCookieCallCount());
    }
@@ -211,7 +211,7 @@ public class MarkupTestCase extends V1ConsumerBaseTest
       ProducerSessionInformation sessionInfo = commonInitCookieTest(handle, behavior, V1CookieProtocol.PER_GROUP.value());
       ExtendedAssert.assertTrue(sessionInfo.isPerGroupCookies());
       ExtendedAssert.assertTrue(sessionInfo.isInitCookieDone());
-      ExtendedAssert.assertNull(sessionInfo.getUserCookie());
+      ExtendedAssert.assertTrue(sessionInfo.getUserCookies().isEmpty());
 
       ExtendedAssert.assertEquals(3, behavior.getInitCookieCallCount());
    }

--- a/consumer/src/test/java/org/gatein/wsrp/protocol/v2/MarkupTestCase.java
+++ b/consumer/src/test/java/org/gatein/wsrp/protocol/v2/MarkupTestCase.java
@@ -298,7 +298,7 @@ public class MarkupTestCase extends V2ConsumerBaseTest
       ExtendedAssert.assertFalse(sessionInfo.isPerGroupCookies());
       ExtendedAssert.assertTrue(sessionInfo.isInitCookieDone());
 
-      ExtendedAssert.assertNotNull(sessionInfo.getUserCookie());
+      ExtendedAssert.assertNotNull(sessionInfo.getUserCookies());
 
       ExtendedAssert.assertEquals(1, behavior.getInitCookieCallCount());
    }
@@ -321,7 +321,7 @@ public class MarkupTestCase extends V2ConsumerBaseTest
       ProducerSessionInformation sessionInfo = commonInitCookieTest(handle, behavior, CookieProtocol.PER_GROUP.value());
       ExtendedAssert.assertTrue(sessionInfo.isPerGroupCookies());
       ExtendedAssert.assertTrue(sessionInfo.isInitCookieDone());
-      ExtendedAssert.assertNull(sessionInfo.getUserCookie());
+      ExtendedAssert.assertTrue(sessionInfo.getUserCookies().isEmpty());
 
       ExtendedAssert.assertEquals(3, behavior.getInitCookieCallCount());
    }

--- a/consumer/src/test/java/org/gatein/wsrp/test/support/CookieSupport.java
+++ b/consumer/src/test/java/org/gatein/wsrp/test/support/CookieSupport.java
@@ -1,0 +1,47 @@
+/*
+* JBoss, a division of Red Hat
+* Copyright 2012, Red Hat Middleware, LLC, and individual contributors as indicated
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+
+package org.gatein.wsrp.test.support;
+
+import org.apache.commons.httpclient.Cookie;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** @author <a href="mailto:chris.laprun@jboss.com">Chris Laprun</a> */
+public class CookieSupport
+{
+   public static List<Cookie> createCookies(Cookie... cookie)
+   {
+      List<Cookie> cookies = new ArrayList<Cookie>(cookie.length);
+      for (Cookie c : cookie)
+      {
+         cookies.add(c);
+      }
+      return cookies;
+   }
+
+   public static Cookie createCookie(String name, String value, int secondsBeforeExpiration)
+   {
+      return new Cookie("domain", name, value, "path", secondsBeforeExpiration, false);
+   }
+}

--- a/test/src/main/java/org/gatein/wsrp/test/handler/MockSOAPMessageContext.java
+++ b/test/src/main/java/org/gatein/wsrp/test/handler/MockSOAPMessageContext.java
@@ -75,7 +75,7 @@ public class MockSOAPMessageContext implements InvocationHandler
          {
             return "http://jboss.com";
          }
-         if (MessageContext.HTTP_REQUEST_HEADERS.equals(args[0]))
+         if (MessageContext.HTTP_REQUEST_HEADERS.equals(args[0]) || MessageContext.HTTP_RESPONSE_HEADERS.equals(args[0]))
          {
             return httpHeaders;
          }


### PR DESCRIPTION
Moved ProducerSessionInformationTestCase to more appropriate package. Made methods that were public for tests package local.
Moved cookie-handling method to CookieUtil.
Switched to using Lists instead of arrays for cookies. Avoid erasing other potentially existing cookies.
Removed unneeded call to resetCurrentlyHeldInformation.
Added debugging information.
Added CookieSupport class.
Simplified and rationalized externalized cookie creation methods.
- CookieUtil: reworked coalesceCookies method and re-implement outputToExternalForm as coalesceAndExternalizeCookies method.
- RequestHeaderClientHandler: Simplified and renamed createCookie(ProducerSessionInformation) to createCoalescedCookieFromCurrentInfo method. Use CookieUtil.coalesceCookies instead of re-implementing it incorrectly. Cleaned-up handleRequest method. Added test cases.
- DirectResourceServingHandler: Simplified cookie handling.
  Make getUserCookie and getGroupCookieFor return a cookie list instead of coalescing into a String. Rename as plural form for better coherence. Adapted test cases.
  Add individual cookies to headers and leave potential coalescing to WS stack.
  Fix NPE issue.
