### PR TITLE
GTNWSRP-370

### DIFF
--- a/admin-gui/src/main/java/org/gatein/wsrp/admin/ui/ConsumerBean.java
+++ b/admin-gui/src/main/java/org/gatein/wsrp/admin/ui/ConsumerBean.java
@@ -434,14 +434,14 @@ public class ConsumerBean extends WSRPManagedBean implements Serializable
          ProducerInfo info = getProducerInfo();
          if (isModified())
          {
+            // save old info in case something goes wrong
+            RegistrationInfo oldReg = getProducerInfo().getRegistrationInfo();
+
             // get updated registration info
             RegistrationInfo newReg = getExpectedRegistrationInfo();
 
             // make sure we save any modified registration properties
             saveToRegistry(info);
-
-            // save old info in case something goes wrong
-            RegistrationInfo oldReg = getProducerInfo().getRegistrationInfo();
 
             // check that we have the proper state
             if (newReg == null)
@@ -461,12 +461,9 @@ public class ConsumerBean extends WSRPManagedBean implements Serializable
 
             try
             {
-               // todo: this should be done better cf regPropListener
-               newReg.setModifiedSinceLastRefresh(true); // mark as modified to force refresh of RegistrationData
                // attempt to modify the registration using new registration info
                info.setRegistrationInfo(newReg);
-               info.modifyRegistration();
-               newReg.setModifiedSinceLastRefresh(false);
+               info.modifyRegistration(true);
 
                beanContext.createInfoMessage(MODIFY_REG_SUCCESS);
             }

--- a/consumer/src/main/java/org/gatein/wsrp/consumer/RegistrationInfo.java
+++ b/consumer/src/main/java/org/gatein/wsrp/consumer/RegistrationInfo.java
@@ -822,7 +822,7 @@ public class RegistrationInfo implements RegistrationProperty.PropertyChangeList
       parent.modifyNow();
    }
 
-   private void setModifyRegistrationNeeded(boolean modifyRegistrationNeeded)
+   void setModifyRegistrationNeeded(boolean modifyRegistrationNeeded)
    {
       this.modifyRegistrationNeeded = modifyRegistrationNeeded;
    }

--- a/consumer/src/main/java/org/gatein/wsrp/consumer/RegistrationProperty.java
+++ b/consumer/src/main/java/org/gatein/wsrp/consumer/RegistrationProperty.java
@@ -228,8 +228,10 @@ public class RegistrationProperty implements Comparable<RegistrationProperty>, S
 
    private void notifyListener(String oldValue, String newValue, Status oldStatus)
    {
-      ParameterValidation.throwIllegalArgExceptionIfNull(listener, "PropertyChangeListener");
-      listener.propertyValueChanged(this, oldStatus, oldValue, newValue);
+      if (listener != null)
+      {
+         listener.propertyValueChanged(this, oldStatus, oldValue, newValue);
+      }
    }
 
    public void setListener(PropertyChangeListener listener)

--- a/jcr-impl/src/main/java/org/gatein/wsrp/consumer/registry/mapping/ProducerInfoMapping.java
+++ b/jcr-impl/src/main/java/org/gatein/wsrp/consumer/registry/mapping/ProducerInfoMapping.java
@@ -108,7 +108,6 @@ public abstract void setAvailable(boolean available);*/
       setExpirationCacheSeconds(producerInfo.getExpirationCacheSeconds());
       setId(producerInfo.getId());
       setLastModified(producerInfo.getLastModified());
-      setModifyRegistrationRequired(producerInfo.isModifyRegistrationRequired());
 
       EndpointInfoMapping eim = getEndpointInfo();
       eim.initFrom(producerInfo.getEndpointConfigurationInfo());
@@ -133,7 +132,6 @@ public abstract void setAvailable(boolean available);*/
       info.setActive(getActive());
       info.setExpirationCacheSeconds(getExpirationCacheSeconds());
       info.setLastModified(getLastModified());
-      info.setModifyRegistrationRequired(getModifyRegistrationRequired());
 
       // endpoint
       EndpointConfigurationInfo endInfo = getEndpointInfo().toModel(info.getEndpointConfigurationInfo(), info);

--- a/jcr-impl/src/main/java/org/gatein/wsrp/consumer/registry/mapping/RegistrationPropertyMapping.java
+++ b/jcr-impl/src/main/java/org/gatein/wsrp/consumer/registry/mapping/RegistrationPropertyMapping.java
@@ -99,9 +99,9 @@ public abstract class RegistrationPropertyMapping implements BaseMapping<Registr
 
       initial.setName(QName.valueOf(getName()));
       initial.setStatus(getStatus());
-      initial.setListener(registrationInfo); // we need to set the listener before we call setValue
       initial.setLang(WSRPConstants.DEFAULT_LOCALE);
       initial.setValue(getValue());
+      initial.setListener(registrationInfo); // we don't want to trigger property changes event here so set the listener after value has been set
 
       final RegistrationPropertyDescriptionMapping descriptionMapping = getDescription();
       if (descriptionMapping != null)


### PR DESCRIPTION
ProducerInfo doesn't record modify registration needed information anymore since it was getting out of sync, delegates it (as it should have) to RegistrationInfo. Fixed ConsumerBean modifyRegistration method and let RegistrationProperty work without a valid listener since we don't want the restore-from-persistence use case to trigger property change events.
