### PR TITLE
GTNWSRP-369

### DIFF
--- a/common/src/main/java/org/gatein/wsrp/WSRPTypeFactory.java
+++ b/common/src/main/java/org/gatein/wsrp/WSRPTypeFactory.java
@@ -1819,7 +1819,7 @@ public class WSRPTypeFactory
 
    public static String getPortletInstanceKey(InstanceContext instanceContext)
    {
-      return instanceContext.getId();
+      return instanceContext == null ? null : instanceContext.getId();
    }
 
    public static String getNamespacePrefix(WindowContext windowContext, String portletHandle)

--- a/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/InvocationHandler.java
+++ b/consumer/src/main/java/org/gatein/wsrp/consumer/handlers/InvocationHandler.java
@@ -30,7 +30,6 @@ import org.gatein.pc.api.StateString;
 import org.gatein.pc.api.invocation.PortletInvocation;
 import org.gatein.pc.api.invocation.response.ErrorResponse;
 import org.gatein.pc.api.invocation.response.PortletInvocationResponse;
-import org.gatein.pc.api.spi.InstanceContext;
 import org.gatein.pc.api.spi.PortletInvocationContext;
 import org.gatein.pc.api.spi.SecurityContext;
 import org.gatein.pc.api.spi.WindowContext;
@@ -173,8 +172,10 @@ public abstract class InvocationHandler<Invocation extends PortletInvocation, Re
             WindowContext windowContext = invocation.getWindowContext();
             runtimeContext.setNamespacePrefix(WSRPTypeFactory.getNamespaceFrom(windowContext));
 
-            InstanceContext instanceContext = invocation.getInstanceContext();
-            runtimeContext.setPortletInstanceKey(instanceContext == null ? null : instanceContext.getId());
+            // GTNWSRP-369: InstanceContext doesn't actually provide any useful information, use WindowContext's id instead
+            /*InstanceContext instanceContext = invocation.getInstanceContext();
+            runtimeContext.setPortletInstanceKey(WSRPTypeFactory.getPortletInstanceKey(instanceContext));*/
+            runtimeContext.setPortletInstanceKey(windowContext.getId());
          }
 
          try

--- a/consumer/src/test/java/org/gatein/wsrp/protocol/v1/MarkupTestCase.java
+++ b/consumer/src/test/java/org/gatein/wsrp/protocol/v1/MarkupTestCase.java
@@ -317,6 +317,7 @@ public class MarkupTestCase extends V1ConsumerBaseTest
       TestPortletInvocationContext ac = new TestPortletInvocationContext();
       ActionInvocation action = new ActionInvocation(ac);
       action.setInstanceContext(new AbstractInstanceContext(portletHandle));
+      action.setWindowContext(new AbstractWindowContext("windowContextId"));
       action.setSecurityContext(new AbstractSecurityContext(MockHttpServletRequest.createMockRequest(null)));
       action.setUserContext(new MockUserContext());
       action.setTarget(PortletContext.createPortletContext(portletHandle, false));

--- a/consumer/src/test/java/org/gatein/wsrp/protocol/v2/MarkupTestCase.java
+++ b/consumer/src/test/java/org/gatein/wsrp/protocol/v2/MarkupTestCase.java
@@ -428,6 +428,7 @@ public class MarkupTestCase extends V2ConsumerBaseTest
       TestPortletInvocationContext ac = new TestPortletInvocationContext();
       ActionInvocation action = new ActionInvocation(ac);
       action.setInstanceContext(new AbstractInstanceContext(portletHandle));
+      action.setWindowContext(new AbstractWindowContext("windowContextId"));
       action.setSecurityContext(new AbstractSecurityContext(MockHttpServletRequest.createMockRequest(null)));
       action.setUserContext(new MockUserContext());
       action.setTarget(PortletContext.createPortletContext(portletHandle, false));

--- a/wsrp-producer-war/src/test/java/org/gatein/wsrp/portlet/SessionPortlet.java
+++ b/wsrp-producer-war/src/test/java/org/gatein/wsrp/portlet/SessionPortlet.java
@@ -21,15 +21,18 @@ package org.gatein.wsrp.portlet;
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA         *
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.                   *
  ******************************************************************************/
-import java.io.IOException;
-import java.io.PrintWriter;
 
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
 import javax.portlet.GenericPortlet;
 import javax.portlet.PortletException;
+import javax.portlet.PortletModeException;
 import javax.portlet.PortletSecurityException;
 import javax.portlet.PortletSession;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
 
 /**
  * A simple portlet to test session handling in WSRP.
@@ -40,6 +43,16 @@ import javax.portlet.RenderResponse;
 public class SessionPortlet extends GenericPortlet
 {
    private static final String COUNT = "count";
+   private static final String NAME = "name";
+
+   public void processAction(ActionRequest req, ActionResponse resp) throws PortletModeException, IOException
+   {
+      String value = req.getParameter(NAME);
+      if (value != null)
+      {
+         req.getPortletSession().setAttribute(NAME, value);
+      }
+   }
 
    protected void doView(RenderRequest req, RenderResponse resp) throws PortletException, PortletSecurityException, IOException
    {
@@ -57,6 +70,15 @@ public class SessionPortlet extends GenericPortlet
       writer.write("<p>Session id: " + session.getId() + "</p>");
       writer.write("<p>count = " + count + "</p>");
       writer.write("<a href='" + resp.createRenderURL() + "'>render</a>");
+
+      StringBuffer sb = new StringBuffer(256);
+      sb.append("<br/><form method='post' action='")
+         .append(resp.createActionURL())
+         .append("'><input name='").append(NAME)
+         .append("'/><input type='submit' value='Submit'></form>")
+         .append("<hr/>Value is ").append(req.getPortletSession().getAttribute(NAME));
+
+      writer.write(sb.toString());
 
       //
       writer.close();


### PR DESCRIPTION
InstanceContext wasn't providing an identifying enough id to use as a portlet instance key so used WindowContext.getId() instead. This should solve the issue of not being able to properly scope portlet session attributes.
