### PR TITLE
Added dependency on jboss-marshalling-river

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
       <javax.xml.ws.version>2.1</javax.xml.ws.version>
       <javax.xml.soap.saaj.version>1.3</javax.xml.soap.saaj.version>
       <org.chromattic.version>1.2.2</org.chromattic.version>
-      <org.jboss.arquillian.version>1.0.2.Final</org.jboss.arquillian.version>
-      <org.jboss.shrinkwrap.version>2.0.0-alpha-4</org.jboss.shrinkwrap.version>
+      <org.jboss.arquillian.version>1.1.1.Final</org.jboss.arquillian.version>
+      <org.jboss.shrinkwrap.version>2.0.0</org.jboss.shrinkwrap.version>
       <org.mockito.version>1.8.5</org.mockito.version>
       <org.apache.cxf.version>2.4.6</org.apache.cxf.version>
       <version.jboss.jbossxb>2.0.1.GA</version.jboss.jbossxb>

--- a/wsrp-producer-war/pom.xml
+++ b/wsrp-producer-war/pom.xml
@@ -196,6 +196,13 @@
                <version>${jbossas.version}</version>
                <scope>test</scope>
             </dependency>
+            <!-- Workaround for https://issues.jboss.org/browse/REMJMX-38 -->
+            <dependency>
+               <groupId>org.jboss.marshalling</groupId>
+               <artifactId>jboss-marshalling-river</artifactId>
+               <version>1.3.6.GA</version>
+               <scope>provided</scope>
+            </dependency>
          </dependencies>
       </profile>
       <profile>
@@ -291,6 +298,7 @@
          <artifactId>test-framework</artifactId>
          <scope>test</scope>
       </dependency>
+
       <dependency>
          <groupId>org.jboss.arquillian.protocol</groupId>
          <artifactId>arquillian-protocol-servlet</artifactId>


### PR DESCRIPTION
On my environment, some tests are failing due to "Could not find a marshaller factory for river marshalling strategy". It seems that the version of the JBoss BOM depends on a version of the JMX which is not properly pulling all the required dependencies, so, we have to pull it ourselves. Fixing this increased the number of tests executed (+147) and decreased the number of failures (-6): https://jenkins.kroehling.de/job/gatein-wsrp/33/testReport/ . Unfortunately, I couldn't find yet an official Jenkins job for WSRP that includes the execution of these tests based on master, only for products. 

Additionally, bumped the versions of Arquillian and Shrinkwrap. 
