### PR TITLE
GTNPORTAL-3282 - Removed the manifest entry for Apache CXF

### DIFF
--- a/wsrp-producer-war/pom.xml
+++ b/wsrp-producer-war/pom.xml
@@ -365,17 +365,6 @@
    <build>
       <plugins>
          <plugin>
-            <artifactId>maven-war-plugin</artifactId>
-            <version>2.2</version>
-            <configuration>
-               <archive>
-                  <manifestEntries>
-                     <Dependencies>org.apache.cxf</Dependencies>
-                  </manifestEntries>
-               </archive>
-            </configuration>
-         </plugin>
-         <plugin>
             <artifactId>maven-jar-plugin</artifactId>
             <configuration>
                <finalName>producer</finalName>


### PR DESCRIPTION
Having a dependency specified in the MANIFEST.MF on a component that is provided by the Application Server causes a warning during startup. The proper way to handle it is via a dependency on the module.xml, which is already in place.

Jenkins build: https://jenkins.kroehling.de/job/gatein-wsrp/71/
