### PR TITLE
GTNWSRP-373 - Removed unused handler chains

### DIFF
--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/MarkupEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/MarkupEndpoint.java
@@ -98,7 +98,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp_services.wsdl",
    endpointInterface = "org.oasis.wsrp.v1.WSRPV1MarkupPortType"
 )
-@HandlerChain(file="../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class MarkupEndpoint extends WSRPBaseEndpoint implements WSRPV1MarkupPortType
 {

--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/PortletManagementEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/PortletManagementEndpoint.java
@@ -90,7 +90,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp_services.wsdl",
    endpointInterface = "org.oasis.wsrp.v1.WSRPV1PortletManagementPortType"
 )
-@HandlerChain(file="../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class PortletManagementEndpoint extends WSRPBaseEndpoint implements WSRPV1PortletManagementPortType
 {

--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/RegistrationEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/RegistrationEndpoint.java
@@ -67,7 +67,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp_services.wsdl",
    endpointInterface = "org.oasis.wsrp.v1.WSRPV1RegistrationPortType"
 )
-@HandlerChain(file = "../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class RegistrationEndpoint extends WSRPBaseEndpoint implements WSRPV1RegistrationPortType
 {

--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/ServiceDescriptionEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v1/ServiceDescriptionEndpoint.java
@@ -64,7 +64,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp_services.wsdl",
    endpointInterface = "org.oasis.wsrp.v1.WSRPV1ServiceDescriptionPortType"
 )
-@HandlerChain(file="../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class ServiceDescriptionEndpoint extends WSRPBaseEndpoint implements WSRPV1ServiceDescriptionPortType
 {

--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/MarkupEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/MarkupEndpoint.java
@@ -88,7 +88,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp-2.0-services.wsdl",
    endpointInterface = "org.oasis.wsrp.v2.WSRPV2MarkupPortType"
 )
-@HandlerChain(file = "../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class MarkupEndpoint extends WSRPBaseEndpoint implements WSRPV2MarkupPortType
 {

--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/PortletManagementEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/PortletManagementEndpoint.java
@@ -98,7 +98,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp-2.0-services.wsdl",
    endpointInterface = "org.oasis.wsrp.v2.WSRPV2PortletManagementPortType"
 )
-@HandlerChain(file = "../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class PortletManagementEndpoint extends WSRPBaseEndpoint implements WSRPV2PortletManagementPortType
 {

--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/RegistrationEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/RegistrationEndpoint.java
@@ -66,7 +66,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp-2.0-services.wsdl",
    endpointInterface = "org.oasis.wsrp.v2.WSRPV2RegistrationPortType"
 )
-@HandlerChain(file = "../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class RegistrationEndpoint extends WSRPBaseEndpoint implements WSRPV2RegistrationPortType
 {

--- a/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/ServiceDescriptionEndpoint.java
+++ b/wsrp-producer-war/src/main/java/org/gatein/wsrp/endpoints/v2/ServiceDescriptionEndpoint.java
@@ -63,7 +63,6 @@ import java.util.List;
    wsdlLocation = "/WEB-INF/wsdl/wsrp-2.0-services.wsdl",
    endpointInterface = "org.oasis.wsrp.v2.WSRPV2ServiceDescriptionPortType"
 )
-@HandlerChain(file = "../producer-handler-chains.xml")
 @Features(features = "org.gatein.wsrp.cxf.WSRPEndpointFeature")
 public class ServiceDescriptionEndpoint extends WSRPBaseEndpoint implements WSRPV2ServiceDescriptionPortType
 {

--- a/wsrp-producer-war/src/main/resources/org/gatein/wsrp/endpoints/producer-handler-chains.xml
+++ b/wsrp-producer-war/src/main/resources/org/gatein/wsrp/endpoints/producer-handler-chains.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<handler-chains xmlns="http://java.sun.com/xml/ns/javaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns1="http://org.jboss.ws/jaxws/samples/logicalhandler"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee javaee_web_services_1_2.xsd">	
-</handler-chains>
-


### PR DESCRIPTION
From EAP 6.2 and on, the web services layer reports a WARN log on the logs when a handler chain file exists, but declares no handler chain. As such, we are removing this, which has the same effect as the current behavior, but won't generate any warns.
